### PR TITLE
feat: add new apis and modify opposite-sentiment api

### DIFF
--- a/app.py
+++ b/app.py
@@ -490,7 +490,8 @@ def get_news_sentiment_and_bias() -> tuple[
         if analyze_result["bias"] is None
         else "" + "sentimentapi error "
         if analyze_result["sentiment"] is None
-        else "" + f": {analyze_result['message']}"
+        else "" + f": {analyze_result['message']}",
+        "debug": "",
     }, http.HTTPStatus.INTERNAL_SERVER_ERROR
 
 
@@ -527,7 +528,8 @@ def get_opposite_news() -> tuple[
         search_result = cast(SearchError, search_result)
         return {
             "message": f"newsdataapi status_code {search_result['status_code']} "
-            f"with message {search_result['message']}"
+            f"with message {search_result['message']}",
+            "debug": "",
         }, http.HTTPStatus.INTERNAL_SERVER_ERROR
     search_result = cast(SearchSuccess, search_result)
     analyze_result = analyze_sentiment(article, request_sentimentapi)
@@ -582,5 +584,6 @@ def search() -> tuple[
     search_result = cast(SearchError, search_result)
     return {
         "message": f"newsdataapi status_code {search_result['status_code']} "
-        f"with message {search_result['message']}"
+        f"with message {search_result['message']}",
+        "debug": "",
     }, http.HTTPStatus.INTERNAL_SERVER_ERROR

--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 import http
 import json
 import os
-from typing import Any, Callable, Literal, Optional, TypedDict, TypeVar, Union, cast
+from typing import Any, Callable, TypeVar, Union, cast
 
 import requests
 from dotenv import load_dotenv
@@ -9,6 +9,28 @@ from flask import Flask, request
 from newsdataapi import NewsDataApiClient
 from werkzeug.exceptions import BadRequestKeyError
 
+from data_types import (
+    BiasAnalysisError,
+    BiasAnalysisSuccess,
+    BiasOkResponse,
+    ErrorResponse,
+    GatewayTimeoutResponse,
+    InternalErrorResponse,
+    News,
+    NewsApiParam,
+    NewsDataApiParam,
+    NewsWithSentiment,
+    OppositeSentimentNewsOkResponse,
+    SearchError,
+    SearchOkResponse,
+    SearchSuccess,
+    SentimentAnalysisError,
+    SentimentAnalysisSuccess,
+    SentimentAndBiasError,
+    SentimentAndBiasOkResponse,
+    SentimentAndBiasSuccess,
+    SentimentOkResponse,
+)
 from news_traveler_sentiment_analysis.sentiment_analysis import (
     sentiment_analysis_per_document,
 )
@@ -18,160 +40,6 @@ load_dotenv()
 NEWSDATAAPI_KEY = os.environ["NEWSDATAAPI_KEY"]
 NEWSAPI_KEY = os.environ["NEWSAPI_KEY"]
 BIASAPI_KEY = os.environ["BIASAPI_KEY"]
-
-
-class OppositeNewsRequest(TypedDict):
-    content: str
-    keyword: str
-
-
-class SentimentRequest(TypedDict):
-    content: str
-
-
-class ErrorResponse(TypedDict):
-    message: str
-
-
-class InternalErrorResponse(TypedDict):
-    message: str
-    debug: str
-
-
-class GatewayTimeoutResponse(TypedDict):
-    reason: str
-
-
-class Sentiment(TypedDict):
-    kind: Literal["positive", "neutral", "negative"]
-    confidence: float
-
-
-class News(TypedDict):
-    source: str
-    author: Optional[str]
-    title: str
-    description: str
-    content: str
-    url: str
-    urlToImage: Optional[str]
-    publishedAt: Optional[str]
-
-
-class NewsWithSentiment(TypedDict):
-    source: str
-    author: Optional[str]
-    title: str
-    description: str
-    content: str
-    url: str
-    urlToImage: Optional[str]
-    publishedAt: Optional[str]
-    sentiment: Sentiment
-
-
-class NewsWithSentimentAndBias(TypedDict):
-    source: str
-    author: Optional[str]
-    title: str
-    description: str
-    content: str
-    url: str
-    urlToImage: Optional[str]
-    publishedAt: Optional[str]
-    sentiment: Sentiment
-    bias: float
-
-
-class SearchOkResponse(TypedDict):
-    count: int
-    results: list[News]
-
-
-class OppositeSentimentNewsOkResponse(TypedDict):
-    count: int
-    results: list[NewsWithSentiment]
-
-
-class SentimentAndBiasOkResponse(TypedDict):
-    sentiment: Sentiment
-    bias: float
-
-
-class SentimentOkResponse(TypedDict):
-    sentiment: Sentiment
-
-
-class BiasOkResponse(TypedDict):
-    bias: float
-
-
-class NewsDataApiParam(TypedDict):
-    country: Optional[str]
-    category: Optional[str]
-    language: Optional[str]
-    domain: Optional[str]
-    q: str
-    qInTitle: Optional[str]
-    page: Optional[int]
-
-
-class NewsApiParam(TypedDict):
-    q: str
-    searchIn: Optional[list[str]]
-    sources: Optional[list[str]]
-    domains: Optional[list[str]]
-    excludeDomains: Optional[list[str]]
-    startFrom: Optional[str]
-    endTo: Optional[str]
-    language: Optional[str]
-    sortBy: Optional[Literal["relevancy", "popularity", "publishedAt"]]
-    pageSize: Optional[int]
-    page: Optional[int]
-
-
-class SearchSuccess(TypedDict):
-    news: list[News]
-
-
-class SearchError(TypedDict):
-    status_code: int
-    message: str
-
-
-class SentimentAndBiasSuccess(TypedDict):
-    sentiment: Sentiment
-    bias: float
-
-
-class SentimentAndBiasError(TypedDict):
-    status_code: int
-    message: str
-    sentiment: Optional[Sentiment]
-    bias: Optional[float]
-
-
-class BiasAnalysisSuccess(TypedDict):
-    value: float
-
-
-class BiasAnalysisError(TypedDict):
-    status_code: int
-    message: str
-
-
-class SentimentAnalysisSuccess(TypedDict):
-    value: Sentiment
-
-
-class SentimentAnalysisError(TypedDict):
-    status_code: int
-    message: str
-
-
-class SentimentAnalysisResult(TypedDict):
-    status_code: int
-    value: Sentiment
 
 
 # A workaround for not using NotRequired

--- a/data_types.py
+++ b/data_types.py
@@ -1,0 +1,155 @@
+from typing import Literal, Optional, TypedDict
+
+
+class OppositeNewsRequest(TypedDict):
+    content: str
+    keyword: str
+
+
+class SentimentRequest(TypedDict):
+    content: str
+
+
+class ErrorResponse(TypedDict):
+    message: str
+
+
+class InternalErrorResponse(TypedDict):
+    message: str
+    debug: str
+
+
+class GatewayTimeoutResponse(TypedDict):
+    reason: str
+
+
+class Sentiment(TypedDict):
+    kind: Literal["positive", "neutral", "negative"]
+    confidence: float
+
+
+class News(TypedDict):
+    source: str
+    author: Optional[str]
+    title: str
+    description: str
+    content: str
+    url: str
+    urlToImage: Optional[str]
+    publishedAt: Optional[str]
+
+
+class NewsWithSentiment(TypedDict):
+    source: str
+    author: Optional[str]
+    title: str
+    description: str
+    content: str
+    url: str
+    urlToImage: Optional[str]
+    publishedAt: Optional[str]
+    sentiment: Sentiment
+
+
+class NewsWithSentimentAndBias(TypedDict):
+    source: str
+    author: Optional[str]
+    title: str
+    description: str
+    content: str
+    url: str
+    urlToImage: Optional[str]
+    publishedAt: Optional[str]
+    sentiment: Sentiment
+    bias: float
+
+
+class SearchOkResponse(TypedDict):
+    count: int
+    results: list[News]
+
+
+class OppositeSentimentNewsOkResponse(TypedDict):
+    count: int
+    results: list[NewsWithSentiment]
+
+
+class SentimentAndBiasOkResponse(TypedDict):
+    sentiment: Sentiment
+    bias: float
+
+
+class SentimentOkResponse(TypedDict):
+    sentiment: Sentiment
+
+
+class BiasOkResponse(TypedDict):
+    bias: float
+
+
+class NewsDataApiParam(TypedDict):
+    country: Optional[str]
+    category: Optional[str]
+    language: Optional[str]
+    domain: Optional[str]
+    q: str
+    qInTitle: Optional[str]
+    page: Optional[int]
+
+
+class NewsApiParam(TypedDict):
+    q: str
+    searchIn: Optional[list[str]]
+    sources: Optional[list[str]]
+    domains: Optional[list[str]]
+    excludeDomains: Optional[list[str]]
+    startFrom: Optional[str]
+    endTo: Optional[str]
+    language: Optional[str]
+    sortBy: Optional[Literal["relevancy", "popularity", "publishedAt"]]
+    pageSize: Optional[int]
+    page: Optional[int]
+
+
+class SearchSuccess(TypedDict):
+    news: list[News]
+
+
+class SearchError(TypedDict):
+    status_code: int
+    message: str
+
+
+class SentimentAndBiasSuccess(TypedDict):
+    sentiment: Sentiment
+    bias: float
+
+
+class SentimentAndBiasError(TypedDict):
+    status_code: int
+    message: str
+    sentiment: Optional[Sentiment]
+    bias: Optional[float]
+
+
+class BiasAnalysisSuccess(TypedDict):
+    value: float
+
+
+class BiasAnalysisError(TypedDict):
+    status_code: int
+    message: str
+
+
+class SentimentAnalysisSuccess(TypedDict):
+    value: Sentiment
+
+
+class SentimentAnalysisError(TypedDict):
+    status_code: int
+    message: str
+
+
+class SentimentAnalysisResult(TypedDict):
+    status_code: int
+    value: Sentiment


### PR DESCRIPTION
rename api: /sentiment --> /sentiment-and-bias
new apis: /sentiment, /bias
update api functionality: /opposite-sentiment-news only filters different sentiment and disregards the bias because bias api is too slow